### PR TITLE
Add performance graphs

### DIFF
--- a/test262/index.html
+++ b/test262/index.html
@@ -109,6 +109,13 @@
           <canvas id="chart-test262-parser-tests"></canvas>
         </div>
       </section>
+      <section>
+        <h2>test262 performance</h2>
+        <p id="summary-test262-performance-tests">Loading...</p>
+        <div class="chart-wrapper">
+          <canvas id="chart-test262-performance-tests"></canvas>
+        </div>
+      </section>
     </main>
     <footer>
       Made by

--- a/test262/index.html
+++ b/test262/index.html
@@ -111,9 +111,15 @@
       </section>
       <section>
         <h2>test262 performance</h2>
-        <p id="summary-test262-performance-tests">Loading...</p>
         <div class="chart-wrapper">
           <canvas id="chart-test262-performance-tests"></canvas>
+        </div>
+      </section>
+      <section>
+        <h2>test262 performance in bytecode interpreter</h2>
+        <p id="summary-test262-bytecode-performance-tests">Loading...</p>
+        <div class="chart-wrapper">
+          <canvas id="chart-test262-bytecode-performance-tests"></canvas>
         </div>
       </section>
     </main>

--- a/test262/index.html
+++ b/test262/index.html
@@ -112,13 +112,13 @@
       <section>
         <h2>test262 performance</h2>
         <div class="chart-wrapper">
-          <canvas id="chart-test262-performance-tests"></canvas>
+          <canvas id="chart-test262-performance"></canvas>
         </div>
       </section>
       <section>
         <h2>test262 performance in bytecode interpreter</h2>
         <div class="chart-wrapper">
-          <canvas id="chart-test262-bytecode-performance-tests"></canvas>
+          <canvas id="chart-test262-bytecode-performance"></canvas>
         </div>
       </section>
     </main>

--- a/test262/index.html
+++ b/test262/index.html
@@ -117,7 +117,6 @@
       </section>
       <section>
         <h2>test262 performance in bytecode interpreter</h2>
-        <p id="summary-test262-bytecode-performance-tests">Loading...</p>
         <div class="chart-wrapper">
           <canvas id="chart-test262-bytecode-performance-tests"></canvas>
         </div>

--- a/test262/main.js
+++ b/test262/main.js
@@ -1,364 +1,358 @@
 "use strict";
 
 (() => {
-    const {
-        DateTime,
-        Duration
-    } = luxon;
+  const { DateTime, Duration } = luxon;
 
-    const style = getComputedStyle(document.body);
-    const backgroundColor = style.getPropertyValue("--color-background");
-    const textColor = style.getPropertyValue("--color-text");
-    const chartPointBorderColor = style.getPropertyValue(
-        "--color-chart-point-border"
-    );
-    const fontFamily = style.getPropertyValue("font-family");
-    const fontSize = parseInt(
-        style.getPropertyValue("font-size").slice(0, -2),
-        10
-    );
+  const style = getComputedStyle(document.body);
+  const backgroundColor = style.getPropertyValue("--color-background");
+  const textColor = style.getPropertyValue("--color-text");
+  const chartPointBorderColor = style.getPropertyValue(
+    "--color-chart-point-border"
+  );
+  const fontFamily = style.getPropertyValue("font-family");
+  const fontSize = parseInt(
+    style.getPropertyValue("font-size").slice(0, -2),
+    10
+  );
 
-    Chart.defaults.borderColor = textColor;
-    Chart.defaults.color = textColor;
-    Chart.defaults.font.family = fontFamily;
-    Chart.defaults.font.size = fontSize;
+  Chart.defaults.borderColor = textColor;
+  Chart.defaults.color = textColor;
+  Chart.defaults.font.family = fontFamily;
+  Chart.defaults.font.size = fontSize;
 
-    const TestResult = {
-        PASSED: "passed",
-        FAILED: "failed",
-        SKIPPED: "skipped",
-        METADATA_ERROR: "metadata_error",
-        HARNESS_ERROR: "harness_error",
-        TIMEOUT_ERROR: "timeout_error",
-        PROCESS_ERROR: "process_error",
-        RUNNER_EXCEPTION: "runner_exception",
-        DURATION: "duration"
-    };
+  const TestResult = {
+    PASSED: "passed",
+    FAILED: "failed",
+    SKIPPED: "skipped",
+    METADATA_ERROR: "metadata_error",
+    HARNESS_ERROR: "harness_error",
+    TIMEOUT_ERROR: "timeout_error",
+    PROCESS_ERROR: "process_error",
+    RUNNER_EXCEPTION: "runner_exception",
+    DURATION: "duration",
+  };
 
-    const TestResultColors = {
-        [TestResult.PASSED]: style.getPropertyValue("--color-chart-passed"),
-        [TestResult.FAILED]: style.getPropertyValue("--color-chart-failed"),
-        [TestResult.SKIPPED]: style.getPropertyValue("--color-chart-skipped"),
-        [TestResult.METADATA_ERROR]: style.getPropertyValue(
-            "--color-chart-metadata-error"
-        ),
-        [TestResult.HARNESS_ERROR]: style.getPropertyValue(
-            "--color-chart-harness-error"
-        ),
-        [TestResult.TIMEOUT_ERROR]: style.getPropertyValue(
-            "--color-chart-timeout-error"
-        ),
-        [TestResult.PROCESS_ERROR]: style.getPropertyValue(
-            "--color-chart-process-error"
-        ),
-        [TestResult.RUNNER_EXCEPTION]: style.getPropertyValue(
-            "--color-chart-runner-exception"
-        ),
-    };
+  const TestResultColors = {
+    [TestResult.PASSED]: style.getPropertyValue("--color-chart-passed"),
+    [TestResult.FAILED]: style.getPropertyValue("--color-chart-failed"),
+    [TestResult.SKIPPED]: style.getPropertyValue("--color-chart-skipped"),
+    [TestResult.METADATA_ERROR]: style.getPropertyValue(
+      "--color-chart-metadata-error"
+    ),
+    [TestResult.HARNESS_ERROR]: style.getPropertyValue(
+      "--color-chart-harness-error"
+    ),
+    [TestResult.TIMEOUT_ERROR]: style.getPropertyValue(
+      "--color-chart-timeout-error"
+    ),
+    [TestResult.PROCESS_ERROR]: style.getPropertyValue(
+      "--color-chart-process-error"
+    ),
+    [TestResult.RUNNER_EXCEPTION]: style.getPropertyValue(
+      "--color-chart-runner-exception"
+    ),
+  };
 
-    const TestResultLabels = {
-        [TestResult.PASSED]: "Passed",
-        [TestResult.FAILED]: "Failed",
-        [TestResult.SKIPPED]: "Skipped",
-        [TestResult.METADATA_ERROR]: "Metadata failed to parse",
-        [TestResult.HARNESS_ERROR]: "Harness file failed to parse or run",
-        [TestResult.TIMEOUT_ERROR]: "Timed out",
-        [TestResult.PROCESS_ERROR]: "Crashed",
-        [TestResult.RUNNER_EXCEPTION]: "Unhandled runner exception",
-        [TestResult.EXECUTION_TIME]: "Execution time",
-        [TestResult.DURATION]: "duration"
-    };
+  const TestResultLabels = {
+    [TestResult.PASSED]: "Passed",
+    [TestResult.FAILED]: "Failed",
+    [TestResult.SKIPPED]: "Skipped",
+    [TestResult.METADATA_ERROR]: "Metadata failed to parse",
+    [TestResult.HARNESS_ERROR]: "Harness file failed to parse or run",
+    [TestResult.TIMEOUT_ERROR]: "Timed out",
+    [TestResult.PROCESS_ERROR]: "Crashed",
+    [TestResult.RUNNER_EXCEPTION]: "Unhandled runner exception",
+    [TestResult.EXECUTION_TIME]: "Execution time",
+    [TestResult.DURATION]: "Duration",
+  };
 
-    function prepareDataForCharts(data) {
-
-
-        const charts = {
-            ...Object.fromEntries(
-                ["test262", "test262-bytecode"].map((name) => [
-                    name,
-                    {
-                        data: {
-                            [TestResult.PASSED]: [],
-                            [TestResult.FAILED]: [],
-                            [TestResult.SKIPPED]: [],
-                            [TestResult.METADATA_ERROR]: [],
-                            [TestResult.HARNESS_ERROR]: [],
-                            [TestResult.TIMEOUT_ERROR]: [],
-                            [TestResult.PROCESS_ERROR]: [],
-                            [TestResult.RUNNER_EXCEPTION]: [],
-                            [TestResult.DURATION]: [],
-                        },
-                        datasets: [],
-                        metadata: [],
-                    },
-                ])
-            ),
-            ["test262-parser-tests"]: {
-                data: {
-                    [TestResult.PASSED]: [],
-                    [TestResult.FAILED]: [],
-                },
-                datasets: [],
-                metadata: [],
+  function prepareDataForCharts(data) {
+    const charts = {
+      ...Object.fromEntries(
+        ["test262", "test262-bytecode"].map((name) => [
+          name,
+          {
+            data: {
+              [TestResult.PASSED]: [],
+              [TestResult.FAILED]: [],
+              [TestResult.SKIPPED]: [],
+              [TestResult.METADATA_ERROR]: [],
+              [TestResult.HARNESS_ERROR]: [],
+              [TestResult.TIMEOUT_ERROR]: [],
+              [TestResult.PROCESS_ERROR]: [],
+              [TestResult.RUNNER_EXCEPTION]: [],
+              [TestResult.DURATION]: [],
             },
-            ["test262-performance-tests"]: {
-                data: {
-                    [TestResult.DURATION]: [],
-                },
-                datasets: [],
-                metadata: [],
-            },
-            ["test262-bytecode-performance-tests"]: {
-                data: {
-                    [TestResult.DURATION]: [],
-                },
-                datasets: [],
-                metadata: [],
-            },
-        };
-        for (const entry of data) {
-            for (const chart in charts) {
-                const results = entry.tests[chart]?.results;
-                if (!results) {
-                    continue;
-                }
-                charts[chart].metadata.push({
-                    commitTimestamp: entry.commit_timestamp,
-                    runTimestamp: entry.run_timestamp,
-                    duration: entry.tests[chart].duration,
-                    versions: entry.versions,
-                    total: results.total,
-                });
-                for (const testResult in results) {
-                    if (testResult === "total") {
-                        continue;
-                    }
-                    charts[chart].data[testResult].push({
-                        x: entry.commit_timestamp * 1000,
-                        y: results[testResult],
-                    });
-                }
-            }
+            datasets: [],
+            metadata: [],
+          },
+        ])
+      ),
+      ["test262-parser-tests"]: {
+        data: {
+          [TestResult.PASSED]: [],
+          [TestResult.FAILED]: [],
+        },
+        datasets: [],
+        metadata: [],
+      },
+      ["test262-performance-tests"]: {
+        data: {
+          [TestResult.DURATION]: [],
+        },
+        datasets: [],
+        metadata: [],
+      },
+      ["test262-bytecode-performance-tests"]: {
+        data: {
+          [TestResult.DURATION]: [],
+        },
+        datasets: [],
+        metadata: [],
+      },
+    };
+    for (const entry of data) {
+      for (const chart in charts) {
+        const results = entry.tests[chart]?.results;
+        if (!results) {
+          continue;
         }
-
-        // chart-test262-performance-tests
-        for (const entry of data) {
-            const referenceChart = entry.tests["test262"];
-            const chart = charts["test262-performance-tests"];
-
-            const results = referenceChart?.results;
-            if (!results) {
-                continue;
-            }
-
-            chart.metadata.push({
-                commitTimestamp: entry.commit_timestamp,
-                runTimestamp: entry.run_timestamp,
-                duration: referenceChart.duration,
-                versions: entry.versions,
-                total: results.total
-            });
-            chart.data["duration"].push({
-                x: entry.commit_timestamp * 1000,
-                y: referenceChart.duration
-            });
+        charts[chart].metadata.push({
+          commitTimestamp: entry.commit_timestamp,
+          runTimestamp: entry.run_timestamp,
+          duration: entry.tests[chart].duration,
+          versions: entry.versions,
+          total: results.total,
+        });
+        for (const testResult in results) {
+          if (testResult === "total") {
+            continue;
+          }
+          charts[chart].data[testResult].push({
+            x: entry.commit_timestamp * 1000,
+            y: results[testResult],
+          });
         }
-
-        // chart-test262-bytecode-performance-tests
-        for (const entry of data) {
-            const referenceChart = entry.tests["test262-bytecode"];
-            const chart = charts["test262-bytecode-performance-tests"];
-
-            const results = referenceChart?.results;
-            if (!results) {
-                continue;
-            }
-
-            chart.metadata.push({
-                commitTimestamp: entry.commit_timestamp,
-                runTimestamp: entry.run_timestamp,
-                duration: referenceChart.duration,
-                versions: entry.versions,
-                total: results.total
-            });
-            chart.data["duration"].push({
-                x: entry.commit_timestamp * 1000,
-                y: referenceChart.duration
-            });
-        }
-
-        for (const chart in charts) {
-            for (const testResult in charts[chart].data) {
-                charts[chart].datasets.push({
-                    label: TestResultLabels[testResult],
-                    data: charts[chart].data[testResult],
-                    backgroundColor: TestResultColors[testResult],
-                    borderWidth: 2,
-                    borderColor: "transparent",
-                    pointRadius: 4,
-                    pointHoverRadius: 6,
-                    pointHitRadius: 4,
-                    pointBorderColor: chartPointBorderColor,
-                    tension: 0.1,
-                    fill: true,
-                });
-            }
-            delete charts[chart].data;
-        }
-
-        return {
-            charts
-        };
+      }
     }
 
-    function initializeChart(element, {
+    const performanceChartStartDateTime = DateTime.fromISO("2021-07-04");
+
+    // chart-test262-performance-tests
+    for (const entry of data) {
+      const dateTimeo = DateTime.fromSeconds(entry.commit_timestamp);
+
+      if (dateTimeo > performanceChartStartDateTime) {
+        const referenceChart = entry.tests["test262"];
+        const chart = charts["test262-performance-tests"];
+        const results = referenceChart?.results;
+        if (!results) {
+          continue;
+        }
+        chart.metadata.push({
+          commitTimestamp: entry.commit_timestamp,
+          runTimestamp: entry.run_timestamp,
+          duration: referenceChart.duration,
+          versions: entry.versions,
+          total: results.total,
+        });
+        chart.data["duration"].push({
+          x: entry.commit_timestamp * 1000,
+          y: referenceChart.duration,
+        });
+      }
+    }
+
+    // chart-test262-bytecode-performance-tests
+    for (const entry of data) {
+      const dateTimeo = DateTime.fromSeconds(entry.commit_timestamp);
+      if (dateTimeo > performanceChartStartDateTime) {
+        const referenceChart = entry.tests["test262-bytecode"];
+        const chart = charts["test262-bytecode-performance-tests"];
+        const results = referenceChart?.results;
+        if (!results) {
+          continue;
+        }
+        chart.metadata.push({
+          commitTimestamp: entry.commit_timestamp,
+          runTimestamp: entry.run_timestamp,
+          duration: referenceChart.duration,
+          versions: entry.versions,
+          total: results.total,
+        });
+        chart.data["duration"].push({
+          x: entry.commit_timestamp * 1000,
+          y: referenceChart.duration,
+        });
+      }
+    }
+
+    for (const chart in charts) {
+      for (const testResult in charts[chart].data) {
+        charts[chart].datasets.push({
+          label: TestResultLabels[testResult],
+          data: charts[chart].data[testResult],
+          backgroundColor: TestResultColors[testResult],
+          borderWidth: 2,
+          borderColor: "transparent",
+          pointRadius: 4,
+          pointHoverRadius: 6,
+          pointHitRadius: 4,
+          pointBorderColor: chartPointBorderColor,
+          tension: 0.1,
+          fill: true,
+        });
+      }
+      delete charts[chart].data;
+    }
+
+    return {
+      charts,
+    };
+  }
+
+  function initializeChart(
+    element,
+    { datasets, metadata },
+    xAxisTitle = "Time",
+    yAxisTitle = "Number of tests"
+  ) {
+    const ctx = element.getContext("2d");
+
+    new Chart(ctx, {
+      type: "line",
+      data: {
         datasets,
-        metadata
-    }, xAxisTitle = "Time", yAxisTitle = "Number of tests") {
-        const ctx = element.getContext("2d");
-
-        new Chart(ctx, {
-            type: "line",
-            data: {
-                datasets,
+      },
+      options: {
+        parsing: false,
+        normalized: true,
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: {
+          zoom: {
+            zoom: {
+              mode: "x",
+              wheel: {
+                enabled: true,
+              },
             },
-            options: {
-                parsing: false,
-                normalized: true,
-                responsive: true,
-                maintainAspectRatio: false,
-                plugins: {
-                    zoom: {
-                        zoom: {
-                            mode: "x",
-                            wheel: {
-                                enabled: true,
-                            },
-                        },
-                        pan: {
-                            enabled: true,
-                            mode: "x",
-                        },
-                    },
-                    tooltip: {
-                        mode: "index",
-                        usePointStyle: true,
-                        boxWidth: 12,
-                        boxHeight: 12,
-                        padding: 20,
-                        titleColor: textColor,
-                        bodyColor: textColor,
-                        footerColor: textColor,
-                        footerFont: {
-                            weight: "normal"
-                        },
-                        footerMarginTop: 20,
-                        backgroundColor: backgroundColor,
-                        callbacks: {
-                            title: () => {
-                                return null;
-                            },
-                            beforeBody: (context) => {
-                                const {
-                                    dataIndex
-                                } = context[0];
-                                const {
-                                    total
-                                } = metadata[dataIndex];
-                                const formattedValue = total.toLocaleString("en-US");
-                                // Leading spaces to make up for missing color circle
-                                return `    Total: ${formattedValue}`;
-                            },
-                            label: (context) => {
-                                // Space as padding between color circle and label
-                                const formattedValue = context.parsed.y.toLocaleString("en-US");
-                                return ` ${context.dataset.label}: ${formattedValue}`;
-                            },
+            pan: {
+              enabled: true,
+              mode: "x",
+            },
+          },
+          tooltip: {
+            mode: "index",
+            usePointStyle: true,
+            boxWidth: 12,
+            boxHeight: 12,
+            padding: 20,
+            titleColor: textColor,
+            bodyColor: textColor,
+            footerColor: textColor,
+            footerFont: {
+              weight: "normal",
+            },
+            footerMarginTop: 20,
+            backgroundColor: backgroundColor,
+            callbacks: {
+              title: () => {
+                return null;
+              },
+              beforeBody: (context) => {
+                const { dataIndex } = context[0];
+                const { total } = metadata[dataIndex];
+                const formattedValue = total.toLocaleString("en-US");
+                // Leading spaces to make up for missing color circle
+                return `    Number of tests: ${formattedValue}`;
+              },
+              label: (context) => {
+                // Space as padding between color circle and label
+                const formattedValue = context.parsed.y.toLocaleString("en-US");
+                return ` ${context.dataset.label}: ${formattedValue}`;
+              },
 
-                            footer: (context) => {
-                                const {
-                                    dataIndex
-                                } = context[0];
-                                const {
-                                    commitTimestamp,
-                                    duration: durationSeconds,
-                                    versions,
-                                } = metadata[dataIndex];
-                                const dateTime = DateTime.fromSeconds(commitTimestamp);
-                                const duration = Duration.fromMillis(durationSeconds * 1000);
-                                const serenityVersion = versions.serenity.substring(0, 7);
-                                // prettier-ignore
-                                const libjsTest262Version = versions["libjs-test262"].substring(0, 7);
-                                const test262Version = versions.test262.substring(0, 7);
-                                // prettier-ignore
-                                const test262ParserTestsVersion = versions["test262-parser-tests"].substring(0, 7);
-                                return `\
+              footer: (context) => {
+                const { dataIndex } = context[0];
+                const {
+                  commitTimestamp,
+                  duration: durationSeconds,
+                  versions,
+                } = metadata[dataIndex];
+                const dateTime = DateTime.fromSeconds(commitTimestamp);
+                const duration = Duration.fromMillis(durationSeconds * 1000);
+                const serenityVersion = versions.serenity.substring(0, 7);
+                // prettier-ignore
+                const libjsTest262Version = versions["libjs-test262"].substring(0, 7);
+                const test262Version = versions.test262.substring(0, 7);
+                // prettier-ignore
+                const test262ParserTestsVersion = versions["test262-parser-tests"].substring(0, 7);
+                return `\
 Committed on ${dateTime.toLocaleString(DateTime.DATETIME_SHORT)}, \
 run took ${duration.toISOTime()}
 
 Versions: serenity@${serenityVersion}, libjs-test262@${libjsTest262Version},
 test262@${test262Version}, test262-parser-tests@${test262ParserTestsVersion}`;
-                            },
-                        },
-                    },
-                    legend: {
-                        align: "end",
-                        labels: {
-                            usePointStyle: true,
-                            boxWidth: 10,
-                            // Only include passed, failed, and crashed in the legend
-                            filter: ({
-                                    text
-                                }) =>
-                                text === TestResultLabels[TestResult.PASSED] ||
-                                text === TestResultLabels[TestResult.FAILED] ||
-                                text === TestResultLabels[TestResult.PROCESS_ERROR],
-                        },
-                    },
-                },
-                scales: {
-                    x: {
-                        type: "time",
-                        title: {
-                            display: true,
-                            text: xAxisTitle,
-                        },
-                        grid: {
-                            borderColor: textColor,
-                            color: "transparent",
-                            borderWidth: 2,
-                        },
-                    },
-                    y: {
-                        stacked: true,
-                        title: {
-                            display: true,
-                            text: yAxisTitle,
-                        },
-                        grid: {
-                            borderColor: textColor,
-                            color: chartPointBorderColor,
-                            borderWidth: 2,
-                        },
-                    },
-                },
+              },
             },
-        });
-    }
+          },
+          legend: {
+            align: "end",
+            labels: {
+              usePointStyle: true,
+              boxWidth: 10,
+              // Only include passed, failed, and crashed in the legend
+              filter: ({ text }) =>
+                text === TestResultLabels[TestResult.PASSED] ||
+                text === TestResultLabels[TestResult.FAILED] ||
+                text === TestResultLabels[TestResult.PROCESS_ERROR],
+            },
+          },
+        },
+        scales: {
+          x: {
+            type: "time",
+            title: {
+              display: true,
+              text: xAxisTitle,
+            },
+            grid: {
+              borderColor: textColor,
+              color: "transparent",
+              borderWidth: 2,
+            },
+          },
+          y: {
+            stacked: true,
+            title: {
+              display: true,
+              text: yAxisTitle,
+            },
+            grid: {
+              borderColor: textColor,
+              color: chartPointBorderColor,
+              borderWidth: 2,
+            },
+          },
+        },
+      },
+    });
+  }
 
-    function initializeSummary(
-        element,
-        runTimestamp,
-        commitHash,
-        durationSeconds,
-        results
-    ) {
-        const dateTime = DateTime.fromSeconds(runTimestamp);
-        const duration = Duration.fromMillis(durationSeconds * 1000);
-        const passed = results[TestResult.PASSED];
-        const total = results.total;
-        const percent = ((passed / total) * 100).toFixed(2);
-        element.innerHTML = `
+  function initializeSummary(
+    element,
+    runTimestamp,
+    commitHash,
+    durationSeconds,
+    results
+  ) {
+    const dateTime = DateTime.fromSeconds(runTimestamp);
+    const duration = Duration.fromMillis(durationSeconds * 1000);
+    const passed = results[TestResult.PASSED];
+    const total = results.total;
+    const percent = ((passed / total) * 100).toFixed(2);
+    element.innerHTML = `
     The last test run was on <strong>
     ${dateTime.toLocaleString(DateTime.DATETIME_SHORT)}
     </strong> for commit
@@ -375,76 +369,74 @@ test262@${test262Version}, test262-parser-tests@${test262ParserTestsVersion}`;
     and took <strong>${duration.toISOTime()}</strong>.
     <strong>${passed} of ${total}</strong> tests passed, i.e. <strong>${percent}%</strong>.
     `;
-    }
+  }
 
-    function initialize(data) {
-        const {
-            charts
-        } = prepareDataForCharts(data);
-        initializeChart(document.getElementById("chart-test262"), charts.test262);
-        initializeChart(
-            document.getElementById("chart-test262-bytecode"),
-            charts["test262-bytecode"]
-        );
-        initializeChart(
-            document.getElementById("chart-test262-parser-tests"),
-            charts["test262-parser-tests"]
-        );
-        initializeChart(
-            document.getElementById("chart-test262-performance-tests"),
-            charts["test262-performance-tests"],
-            "Time",
-            "Duration"
-        );
-        initializeChart(
-            document.getElementById("chart-test262-bytecode-performance-tests"),
-            charts["test262-bytecode-performance-tests"],
-            "Time",
-            "Duration"
-        );
-        const last = data.slice(-1)[0];
-        initializeSummary(
-            document.getElementById("summary-test262"),
-            last.run_timestamp,
-            last.versions.serenity,
-            last.tests.test262.duration,
-            last.tests.test262.results
-        );
-        initializeSummary(
-            document.getElementById("summary-test262-bytecode"),
-            last.run_timestamp,
-            last.versions.serenity,
-            last.tests["test262-bytecode"].duration,
-            last.tests["test262-bytecode"].results
-        );
-        initializeSummary(
-            document.getElementById("summary-test262-parser-tests"),
-            last.run_timestamp,
-            last.versions.serenity,
-            last.tests["test262-parser-tests"].duration,
-            last.tests["test262-parser-tests"].results
-        );
-    }
+  function initialize(data) {
+    const { charts } = prepareDataForCharts(data);
+    initializeChart(document.getElementById("chart-test262"), charts.test262);
+    initializeChart(
+      document.getElementById("chart-test262-bytecode"),
+      charts["test262-bytecode"]
+    );
+    initializeChart(
+      document.getElementById("chart-test262-parser-tests"),
+      charts["test262-parser-tests"]
+    );
+    initializeChart(
+      document.getElementById("chart-test262-performance-tests"),
+      charts["test262-performance-tests"],
+      "Time",
+      "Duration"
+    );
+    initializeChart(
+      document.getElementById("chart-test262-bytecode-performance-tests"),
+      charts["test262-bytecode-performance-tests"],
+      "Time",
+      "Duration"
+    );
+    const last = data.slice(-1)[0];
+    initializeSummary(
+      document.getElementById("summary-test262"),
+      last.run_timestamp,
+      last.versions.serenity,
+      last.tests.test262.duration,
+      last.tests.test262.results
+    );
+    initializeSummary(
+      document.getElementById("summary-test262-bytecode"),
+      last.run_timestamp,
+      last.versions.serenity,
+      last.tests["test262-bytecode"].duration,
+      last.tests["test262-bytecode"].results
+    );
+    initializeSummary(
+      document.getElementById("summary-test262-parser-tests"),
+      last.run_timestamp,
+      last.versions.serenity,
+      last.tests["test262-parser-tests"].duration,
+      last.tests["test262-parser-tests"].results
+    );
+  }
 
-    document.addEventListener("DOMContentLoaded", () => {
-        const headers = new Headers();
-        headers.append("pragma", "no-cache");
-        headers.append("cache-control", "no-cache");
-        fetch(new Request("data/results.json"), {
-                method: "GET",
-                headers
-            })
-            .then((response) => response.json())
-            .then((data) => {
-                data.sort((a, b) =>
-                    a.commit_timestamp === b.commit_timestamp ?
-                    0 :
-                    a.commit_timestamp < b.commit_timestamp ?
-                    -1 :
-                    1
-                );
-                return data;
-            })
-            .then((data) => initialize(data));
-    });
+  document.addEventListener("DOMContentLoaded", () => {
+    const headers = new Headers();
+    headers.append("pragma", "no-cache");
+    headers.append("cache-control", "no-cache");
+    fetch(new Request("data/results.json"), {
+      method: "GET",
+      headers,
+    })
+      .then((response) => response.json())
+      .then((data) => {
+        data.sort((a, b) =>
+          a.commit_timestamp === b.commit_timestamp
+            ? 0
+            : a.commit_timestamp < b.commit_timestamp
+            ? -1
+            : 1
+        );
+        return data;
+      })
+      .then((data) => initialize(data));
+  });
 })();

--- a/test262/main.js
+++ b/test262/main.js
@@ -199,9 +199,7 @@
       delete charts[chart].data;
     }
 
-    return {
-      charts,
-    };
+    return { charts };
   }
 
   function initializeChart(
@@ -244,9 +242,7 @@
             titleColor: textColor,
             bodyColor: textColor,
             footerColor: textColor,
-            footerFont: {
-              weight: "normal",
-            },
+            footerFont: { weight: "normal" },
             footerMarginTop: 20,
             backgroundColor: backgroundColor,
             callbacks: {
@@ -415,10 +411,7 @@ test262@${test262Version}, test262-parser-tests@${test262ParserTestsVersion}`;
     const headers = new Headers();
     headers.append("pragma", "no-cache");
     headers.append("cache-control", "no-cache");
-    fetch(new Request("data/results.json"), {
-      method: "GET",
-      headers,
-    })
+    fetch(new Request("data/results.json"), { method: "GET", headers })
       .then((response) => response.json())
       .then((data) => {
         data.sort((a, b) =>

--- a/test262/main.js
+++ b/test262/main.js
@@ -118,23 +118,24 @@
     for (const entry of data) {
       for (const chart in charts) {
         const results = entry.tests[chart]?.results;
-        if (results) {
-          charts[chart].metadata.push({
-            commitTimestamp: entry.commit_timestamp,
-            runTimestamp: entry.run_timestamp,
-            duration: entry.tests[chart].duration,
-            versions: entry.versions,
-            total: results.total,
-          });
-          for (const testResult in results) {
-            if (testResult === "total") {
-              continue;
-            }
-            charts[chart].data[testResult].push({
-              x: entry.commit_timestamp * 1000,
-              y: results[testResult],
-            });
+        if (!results) {
+          continue;
+        }
+        charts[chart].metadata.push({
+          commitTimestamp: entry.commit_timestamp,
+          runTimestamp: entry.run_timestamp,
+          duration: entry.tests[chart].duration,
+          versions: entry.versions,
+          total: results.total,
+        });
+        for (const testResult in results) {
+          if (testResult === "total") {
+            continue;
           }
+          charts[chart].data[testResult].push({
+            x: entry.commit_timestamp * 1000,
+            y: results[testResult],
+          });
         }
       }
 

--- a/test262/main.js
+++ b/test262/main.js
@@ -138,10 +138,10 @@
 
     const performanceChartStartDateTime = DateTime.fromISO("2021-07-04");
 
-    // chart-test262-performance-tests
     for (const entry of data) {
       const dt = DateTime.fromSeconds(entry.commit_timestamp);
       if (dt > performanceChartStartDateTime) {
+        // chart-test262-performance-tests
         const referenceChart = entry.tests["test262"];
         const chart = charts["test262-performance-tests"];
         const results = referenceChart?.results;
@@ -159,30 +159,24 @@
           x: entry.commit_timestamp * 1000,
           y: referenceChart.duration,
         });
-      }
-    }
 
-    // chart-test262-bytecode-performance-tests
-    for (const entry of data) {
-      const dt = DateTime.fromSeconds(entry.commit_timestamp);
-      if (dt > performanceChartStartDateTime) {
-        const referenceChart = entry.tests["test262-bytecode"];
-        const chart = charts["test262-bytecode-performance-tests"];
-        const results = referenceChart?.results;
-        if (!results) {
-          continue;
+        // chart-test262-bytecode-performance-tests
+        const byteCodeReferenceChart = entry.tests["test262-bytecode"];
+        const byteCodeChart = charts["test262-bytecode-performance-tests"];
+        const byteCodeResults = byteCodeReferenceChart?.results;
+        if (byteCodeReferenceChart) {
+          chart.metadata.push({
+            commitTimestamp: entry.commit_timestamp,
+            runTimestamp: entry.run_timestamp,
+            duration: referenceChart.duration,
+            versions: entry.versions,
+            total: byteCodeResults.total,
+          });
+          byteCodeChart.data["duration"].push({
+            x: entry.commit_timestamp * 1000,
+            y: byteCodeReferenceChart.duration,
+          });
         }
-        chart.metadata.push({
-          commitTimestamp: entry.commit_timestamp,
-          runTimestamp: entry.run_timestamp,
-          duration: referenceChart.duration,
-          versions: entry.versions,
-          total: results.total,
-        });
-        chart.data["duration"].push({
-          x: entry.commit_timestamp * 1000,
-          y: referenceChart.duration,
-        });
       }
     }
 

--- a/test262/main.js
+++ b/test262/main.js
@@ -1,288 +1,364 @@
 "use strict";
 
 (() => {
-  const { DateTime, Duration } = luxon;
+    const {
+        DateTime,
+        Duration
+    } = luxon;
 
-  const style = getComputedStyle(document.body);
-  const backgroundColor = style.getPropertyValue("--color-background");
-  const textColor = style.getPropertyValue("--color-text");
-  const chartPointBorderColor = style.getPropertyValue(
-    "--color-chart-point-border"
-  );
-  const fontFamily = style.getPropertyValue("font-family");
-  const fontSize = parseInt(
-    style.getPropertyValue("font-size").slice(0, -2),
-    10
-  );
+    const style = getComputedStyle(document.body);
+    const backgroundColor = style.getPropertyValue("--color-background");
+    const textColor = style.getPropertyValue("--color-text");
+    const chartPointBorderColor = style.getPropertyValue(
+        "--color-chart-point-border"
+    );
+    const fontFamily = style.getPropertyValue("font-family");
+    const fontSize = parseInt(
+        style.getPropertyValue("font-size").slice(0, -2),
+        10
+    );
 
-  Chart.defaults.borderColor = textColor;
-  Chart.defaults.color = textColor;
-  Chart.defaults.font.family = fontFamily;
-  Chart.defaults.font.size = fontSize;
+    Chart.defaults.borderColor = textColor;
+    Chart.defaults.color = textColor;
+    Chart.defaults.font.family = fontFamily;
+    Chart.defaults.font.size = fontSize;
 
-  const TestResult = {
-    PASSED: "passed",
-    FAILED: "failed",
-    SKIPPED: "skipped",
-    METADATA_ERROR: "metadata_error",
-    HARNESS_ERROR: "harness_error",
-    TIMEOUT_ERROR: "timeout_error",
-    PROCESS_ERROR: "process_error",
-    RUNNER_EXCEPTION: "runner_exception",
-  };
-
-  const TestResultColors = {
-    [TestResult.PASSED]: style.getPropertyValue("--color-chart-passed"),
-    [TestResult.FAILED]: style.getPropertyValue("--color-chart-failed"),
-    [TestResult.SKIPPED]: style.getPropertyValue("--color-chart-skipped"),
-    [TestResult.METADATA_ERROR]: style.getPropertyValue(
-      "--color-chart-metadata-error"
-    ),
-    [TestResult.HARNESS_ERROR]: style.getPropertyValue(
-      "--color-chart-harness-error"
-    ),
-    [TestResult.TIMEOUT_ERROR]: style.getPropertyValue(
-      "--color-chart-timeout-error"
-    ),
-    [TestResult.PROCESS_ERROR]: style.getPropertyValue(
-      "--color-chart-process-error"
-    ),
-    [TestResult.RUNNER_EXCEPTION]: style.getPropertyValue(
-      "--color-chart-runner-exception"
-    ),
-  };
-
-  const TestResultLabels = {
-    [TestResult.PASSED]: "Passed",
-    [TestResult.FAILED]: "Failed",
-    [TestResult.SKIPPED]: "Skipped",
-    [TestResult.METADATA_ERROR]: "Metadata failed to parse",
-    [TestResult.HARNESS_ERROR]: "Harness file failed to parse or run",
-    [TestResult.TIMEOUT_ERROR]: "Timed out",
-    [TestResult.PROCESS_ERROR]: "Crashed",
-    [TestResult.RUNNER_EXCEPTION]: "Unhandled runner exception",
-    [TestResult.EXECUTION_TIME]: "Execution time",
-  };
-
-  function prepareDataForCharts(data) {
-    const charts = {
-      ...Object.fromEntries(
-        ["test262", "test262-bytecode"].map((name) => [
-          name,
-          {
-            data: {
-              [TestResult.PASSED]: [],
-              [TestResult.FAILED]: [],
-              [TestResult.SKIPPED]: [],
-              [TestResult.METADATA_ERROR]: [],
-              [TestResult.HARNESS_ERROR]: [],
-              [TestResult.TIMEOUT_ERROR]: [],
-              [TestResult.PROCESS_ERROR]: [],
-              [TestResult.RUNNER_EXCEPTION]: [],
-            },
-            datasets: [],
-            metadata: [],
-          },
-        ])
-      ),
-      ["test262-parser-tests"]: {
-        data: {
-          [TestResult.PASSED]: [],
-          [TestResult.FAILED]: [],
-        },
-        datasets: [],
-        metadata: [],
-      },
-      ["test262-performance-tests"]: {
-        data: {
-          [TestResult.EXECUTION_TIME]: [],
-        },
-        datasets: [],
-        metadata: [],
-      },
+    const TestResult = {
+        PASSED: "passed",
+        FAILED: "failed",
+        SKIPPED: "skipped",
+        METADATA_ERROR: "metadata_error",
+        HARNESS_ERROR: "harness_error",
+        TIMEOUT_ERROR: "timeout_error",
+        PROCESS_ERROR: "process_error",
+        RUNNER_EXCEPTION: "runner_exception",
+        DURATION: "duration"
     };
-    for (const entry of data) {
-      for (const chart in charts) {
-        const results = entry.tests[chart]?.results;
-        if (!results) {
-          continue;
+
+    const TestResultColors = {
+        [TestResult.PASSED]: style.getPropertyValue("--color-chart-passed"),
+        [TestResult.FAILED]: style.getPropertyValue("--color-chart-failed"),
+        [TestResult.SKIPPED]: style.getPropertyValue("--color-chart-skipped"),
+        [TestResult.METADATA_ERROR]: style.getPropertyValue(
+            "--color-chart-metadata-error"
+        ),
+        [TestResult.HARNESS_ERROR]: style.getPropertyValue(
+            "--color-chart-harness-error"
+        ),
+        [TestResult.TIMEOUT_ERROR]: style.getPropertyValue(
+            "--color-chart-timeout-error"
+        ),
+        [TestResult.PROCESS_ERROR]: style.getPropertyValue(
+            "--color-chart-process-error"
+        ),
+        [TestResult.RUNNER_EXCEPTION]: style.getPropertyValue(
+            "--color-chart-runner-exception"
+        ),
+    };
+
+    const TestResultLabels = {
+        [TestResult.PASSED]: "Passed",
+        [TestResult.FAILED]: "Failed",
+        [TestResult.SKIPPED]: "Skipped",
+        [TestResult.METADATA_ERROR]: "Metadata failed to parse",
+        [TestResult.HARNESS_ERROR]: "Harness file failed to parse or run",
+        [TestResult.TIMEOUT_ERROR]: "Timed out",
+        [TestResult.PROCESS_ERROR]: "Crashed",
+        [TestResult.RUNNER_EXCEPTION]: "Unhandled runner exception",
+        [TestResult.EXECUTION_TIME]: "Execution time",
+        [TestResult.DURATION]: "duration"
+    };
+
+    function prepareDataForCharts(data) {
+
+
+        const charts = {
+            ...Object.fromEntries(
+                ["test262", "test262-bytecode"].map((name) => [
+                    name,
+                    {
+                        data: {
+                            [TestResult.PASSED]: [],
+                            [TestResult.FAILED]: [],
+                            [TestResult.SKIPPED]: [],
+                            [TestResult.METADATA_ERROR]: [],
+                            [TestResult.HARNESS_ERROR]: [],
+                            [TestResult.TIMEOUT_ERROR]: [],
+                            [TestResult.PROCESS_ERROR]: [],
+                            [TestResult.RUNNER_EXCEPTION]: [],
+                            [TestResult.DURATION]: [],
+                        },
+                        datasets: [],
+                        metadata: [],
+                    },
+                ])
+            ),
+            ["test262-parser-tests"]: {
+                data: {
+                    [TestResult.PASSED]: [],
+                    [TestResult.FAILED]: [],
+                },
+                datasets: [],
+                metadata: [],
+            },
+            ["test262-performance-tests"]: {
+                data: {
+                    [TestResult.DURATION]: [],
+                },
+                datasets: [],
+                metadata: [],
+            },
+            ["test262-bytecode-performance-tests"]: {
+                data: {
+                    [TestResult.DURATION]: [],
+                },
+                datasets: [],
+                metadata: [],
+            },
+        };
+        for (const entry of data) {
+            for (const chart in charts) {
+                const results = entry.tests[chart]?.results;
+                if (!results) {
+                    continue;
+                }
+                charts[chart].metadata.push({
+                    commitTimestamp: entry.commit_timestamp,
+                    runTimestamp: entry.run_timestamp,
+                    duration: entry.tests[chart].duration,
+                    versions: entry.versions,
+                    total: results.total,
+                });
+                for (const testResult in results) {
+                    if (testResult === "total") {
+                        continue;
+                    }
+                    charts[chart].data[testResult].push({
+                        x: entry.commit_timestamp * 1000,
+                        y: results[testResult],
+                    });
+                }
+            }
         }
-        charts[chart].metadata.push({
-          commitTimestamp: entry.commit_timestamp,
-          runTimestamp: entry.run_timestamp,
-          duration: entry.tests[chart].duration,
-          versions: entry.versions,
-          total: results.total,
-        });
-        for (const testResult in results) {
-          if (testResult === "total") {
-            continue;
-          }
-          charts[chart].data[testResult].push({
-            x: entry.commit_timestamp * 1000,
-            y: results[testResult],
-          });
+
+        // chart-test262-performance-tests
+        for (const entry of data) {
+            const referenceChart = entry.tests["test262"];
+            const chart = charts["test262-performance-tests"];
+
+            const results = referenceChart?.results;
+            if (!results) {
+                continue;
+            }
+
+            chart.metadata.push({
+                commitTimestamp: entry.commit_timestamp,
+                runTimestamp: entry.run_timestamp,
+                duration: referenceChart.duration,
+                versions: entry.versions,
+                total: results.total
+            });
+            chart.data["duration"].push({
+                x: entry.commit_timestamp * 1000,
+                y: referenceChart.duration
+            });
         }
-      }
+
+        // chart-test262-bytecode-performance-tests
+        for (const entry of data) {
+            const referenceChart = entry.tests["test262-bytecode"];
+            const chart = charts["test262-bytecode-performance-tests"];
+
+            const results = referenceChart?.results;
+            if (!results) {
+                continue;
+            }
+
+            chart.metadata.push({
+                commitTimestamp: entry.commit_timestamp,
+                runTimestamp: entry.run_timestamp,
+                duration: referenceChart.duration,
+                versions: entry.versions,
+                total: results.total
+            });
+            chart.data["duration"].push({
+                x: entry.commit_timestamp * 1000,
+                y: referenceChart.duration
+            });
+        }
+
+        for (const chart in charts) {
+            for (const testResult in charts[chart].data) {
+                charts[chart].datasets.push({
+                    label: TestResultLabels[testResult],
+                    data: charts[chart].data[testResult],
+                    backgroundColor: TestResultColors[testResult],
+                    borderWidth: 2,
+                    borderColor: "transparent",
+                    pointRadius: 4,
+                    pointHoverRadius: 6,
+                    pointHitRadius: 4,
+                    pointBorderColor: chartPointBorderColor,
+                    tension: 0.1,
+                    fill: true,
+                });
+            }
+            delete charts[chart].data;
+        }
+
+        return {
+            charts
+        };
     }
 
-    for (const chart in charts) {
-      for (const testResult in charts[chart].data) {
-        charts[chart].datasets.push({
-          label: TestResultLabels[testResult],
-          data: charts[chart].data[testResult],
-          backgroundColor: TestResultColors[testResult],
-          borderWidth: 2,
-          borderColor: "transparent",
-          pointRadius: 4,
-          pointHoverRadius: 6,
-          pointHitRadius: 4,
-          pointBorderColor: chartPointBorderColor,
-          tension: 0.1,
-          fill: true,
-        });
-      }
-      delete charts[chart].data;
-    }
-
-    return { charts };
-  }
-
-  function initializeChart(element, { datasets, metadata }, xAxisTitle = "Time", yAxisTitle = "Number of tests") {
-    const ctx = element.getContext("2d");
-
-    new Chart(ctx, {
-      type: "line",
-      data: {
+    function initializeChart(element, {
         datasets,
-      },
-      options: {
-        parsing: false,
-        normalized: true,
-        responsive: true,
-        maintainAspectRatio: false,
-        plugins: {
-          zoom: {
-            zoom: {
-              mode: "x",
-              wheel: {
-                enabled: true,
-              },
-            },
-            pan: {
-              enabled: true,
-              mode: "x",
-            },
-          },
-          tooltip: {
-            mode: "index",
-            usePointStyle: true,
-            boxWidth: 12,
-            boxHeight: 12,
-            padding: 20,
-            titleColor: textColor,
-            bodyColor: textColor,
-            footerColor: textColor,
-            footerFont: { weight: "normal" },
-            footerMarginTop: 20,
-            backgroundColor: backgroundColor,
-            callbacks: {
-              title: () => {
-                return null;
-              },
-              beforeBody: (context) => {
-                const { dataIndex } = context[0];
-                const { total } = metadata[dataIndex];
-                const formattedValue = total.toLocaleString("en-US");
-                // Leading spaces to make up for missing color circle
-                return `    Total: ${formattedValue}`;
-              },
-              label: (context) => {
-                // Space as padding between color circle and label
-                const formattedValue = context.parsed.y.toLocaleString("en-US");
-                return ` ${context.dataset.label}: ${formattedValue}`;
-              },
+        metadata
+    }, xAxisTitle = "Time", yAxisTitle = "Number of tests") {
+        const ctx = element.getContext("2d");
 
-              footer: (context) => {
-                const { dataIndex } = context[0];
-                const {
-                  commitTimestamp,
-                  duration: durationSeconds,
-                  versions,
-                } = metadata[dataIndex];
-                const dateTime = DateTime.fromSeconds(commitTimestamp);
-                const duration = Duration.fromMillis(durationSeconds * 1000);
-                const serenityVersion = versions.serenity.substring(0, 7);
-                // prettier-ignore
-                const libjsTest262Version = versions["libjs-test262"].substring(0, 7);
-                const test262Version = versions.test262.substring(0, 7);
-                // prettier-ignore
-                const test262ParserTestsVersion = versions["test262-parser-tests"].substring(0, 7);
-                return `\
+        new Chart(ctx, {
+            type: "line",
+            data: {
+                datasets,
+            },
+            options: {
+                parsing: false,
+                normalized: true,
+                responsive: true,
+                maintainAspectRatio: false,
+                plugins: {
+                    zoom: {
+                        zoom: {
+                            mode: "x",
+                            wheel: {
+                                enabled: true,
+                            },
+                        },
+                        pan: {
+                            enabled: true,
+                            mode: "x",
+                        },
+                    },
+                    tooltip: {
+                        mode: "index",
+                        usePointStyle: true,
+                        boxWidth: 12,
+                        boxHeight: 12,
+                        padding: 20,
+                        titleColor: textColor,
+                        bodyColor: textColor,
+                        footerColor: textColor,
+                        footerFont: {
+                            weight: "normal"
+                        },
+                        footerMarginTop: 20,
+                        backgroundColor: backgroundColor,
+                        callbacks: {
+                            title: () => {
+                                return null;
+                            },
+                            beforeBody: (context) => {
+                                const {
+                                    dataIndex
+                                } = context[0];
+                                const {
+                                    total
+                                } = metadata[dataIndex];
+                                const formattedValue = total.toLocaleString("en-US");
+                                // Leading spaces to make up for missing color circle
+                                return `    Total: ${formattedValue}`;
+                            },
+                            label: (context) => {
+                                // Space as padding between color circle and label
+                                const formattedValue = context.parsed.y.toLocaleString("en-US");
+                                return ` ${context.dataset.label}: ${formattedValue}`;
+                            },
+
+                            footer: (context) => {
+                                const {
+                                    dataIndex
+                                } = context[0];
+                                const {
+                                    commitTimestamp,
+                                    duration: durationSeconds,
+                                    versions,
+                                } = metadata[dataIndex];
+                                const dateTime = DateTime.fromSeconds(commitTimestamp);
+                                const duration = Duration.fromMillis(durationSeconds * 1000);
+                                const serenityVersion = versions.serenity.substring(0, 7);
+                                // prettier-ignore
+                                const libjsTest262Version = versions["libjs-test262"].substring(0, 7);
+                                const test262Version = versions.test262.substring(0, 7);
+                                // prettier-ignore
+                                const test262ParserTestsVersion = versions["test262-parser-tests"].substring(0, 7);
+                                return `\
 Committed on ${dateTime.toLocaleString(DateTime.DATETIME_SHORT)}, \
 run took ${duration.toISOTime()}
 
 Versions: serenity@${serenityVersion}, libjs-test262@${libjsTest262Version},
 test262@${test262Version}, test262-parser-tests@${test262ParserTestsVersion}`;
-              },
+                            },
+                        },
+                    },
+                    legend: {
+                        align: "end",
+                        labels: {
+                            usePointStyle: true,
+                            boxWidth: 10,
+                            // Only include passed, failed, and crashed in the legend
+                            filter: ({
+                                    text
+                                }) =>
+                                text === TestResultLabels[TestResult.PASSED] ||
+                                text === TestResultLabels[TestResult.FAILED] ||
+                                text === TestResultLabels[TestResult.PROCESS_ERROR],
+                        },
+                    },
+                },
+                scales: {
+                    x: {
+                        type: "time",
+                        title: {
+                            display: true,
+                            text: xAxisTitle,
+                        },
+                        grid: {
+                            borderColor: textColor,
+                            color: "transparent",
+                            borderWidth: 2,
+                        },
+                    },
+                    y: {
+                        stacked: true,
+                        title: {
+                            display: true,
+                            text: yAxisTitle,
+                        },
+                        grid: {
+                            borderColor: textColor,
+                            color: chartPointBorderColor,
+                            borderWidth: 2,
+                        },
+                    },
+                },
             },
-          },
-          legend: {
-            align: "end",
-            labels: {
-              usePointStyle: true,
-              boxWidth: 10,
-              // Only include passed, failed, and crashed in the legend
-              filter: ({ text }) =>
-                text === TestResultLabels[TestResult.PASSED] ||
-                text === TestResultLabels[TestResult.FAILED] ||
-                text === TestResultLabels[TestResult.PROCESS_ERROR],
-            },
-          },
-        },
-        scales: {
-          x: {
-            type: "time",
-            title: {
-              display: true,
-              text: xAxisTitle,
-            },
-            grid: {
-              borderColor: textColor,
-              color: "transparent",
-              borderWidth: 2,
-            },
-          },
-          y: {
-            stacked: true,
-            title: {
-              display: true,
-              text: yAxisTitle,
-            },
-            grid: {
-              borderColor: textColor,
-              color: chartPointBorderColor,
-              borderWidth: 2,
-            },
-          },
-        },
-      },
-    });
-  }
+        });
+    }
 
-  function initializeSummary(
-    element,
-    runTimestamp,
-    commitHash,
-    durationSeconds,
-    results
-  ) {
-    const dateTime = DateTime.fromSeconds(runTimestamp);
-    const duration = Duration.fromMillis(durationSeconds * 1000);
-    const passed = results[TestResult.PASSED];
-    const total = results.total;
-    const percent = ((passed / total) * 100).toFixed(2);
-    element.innerHTML = `
+    function initializeSummary(
+        element,
+        runTimestamp,
+        commitHash,
+        durationSeconds,
+        results
+    ) {
+        const dateTime = DateTime.fromSeconds(runTimestamp);
+        const duration = Duration.fromMillis(durationSeconds * 1000);
+        const passed = results[TestResult.PASSED];
+        const total = results.total;
+        const percent = ((passed / total) * 100).toFixed(2);
+        element.innerHTML = `
     The last test run was on <strong>
     ${dateTime.toLocaleString(DateTime.DATETIME_SHORT)}
     </strong> for commit
@@ -299,66 +375,76 @@ test262@${test262Version}, test262-parser-tests@${test262ParserTestsVersion}`;
     and took <strong>${duration.toISOTime()}</strong>.
     <strong>${passed} of ${total}</strong> tests passed, i.e. <strong>${percent}%</strong>.
     `;
-  }
+    }
 
-  function initialize(data) {
-    const { charts } = prepareDataForCharts(data);
-    initializeChart(document.getElementById("chart-test262"), charts.test262);
-    initializeChart(
-      document.getElementById("chart-test262-bytecode"),
-      charts["test262-bytecode"]
-    );
-    initializeChart(
-      document.getElementById("chart-test262-parser-tests"),
-      charts["test262-parser-tests"]
-    );
-    initializeChart(
-      document.getElementById("chart-test262-performance-tests"),
-      charts["test262-performance-tests"],
-      "Date/time",
-      "Execution time"
-    );
-    const last = data.slice(-1)[0];
-    initializeSummary(
-      document.getElementById("summary-test262"),
-      last.run_timestamp,
-      last.versions.serenity,
-      last.tests.test262.duration,
-      last.tests.test262.results
-    );
-    initializeSummary(
-      document.getElementById("summary-test262-bytecode"),
-      last.run_timestamp,
-      last.versions.serenity,
-      last.tests["test262-bytecode"].duration,
-      last.tests["test262-bytecode"].results
-    );
-    initializeSummary(
-      document.getElementById("summary-test262-parser-tests"),
-      last.run_timestamp,
-      last.versions.serenity,
-      last.tests["test262-parser-tests"].duration,
-      last.tests["test262-parser-tests"].results
-    );
-    // TODO: Init summary for performance
-  }
-
-  document.addEventListener("DOMContentLoaded", () => {
-    const headers = new Headers();
-    headers.append("pragma", "no-cache");
-    headers.append("cache-control", "no-cache");
-    fetch(new Request("data/results.json"), { method: "GET", headers })
-      .then((response) => response.json())
-      .then((data) => {
-        data.sort((a, b) =>
-          a.commit_timestamp === b.commit_timestamp
-            ? 0
-            : a.commit_timestamp < b.commit_timestamp
-            ? -1
-            : 1
+    function initialize(data) {
+        const {
+            charts
+        } = prepareDataForCharts(data);
+        initializeChart(document.getElementById("chart-test262"), charts.test262);
+        initializeChart(
+            document.getElementById("chart-test262-bytecode"),
+            charts["test262-bytecode"]
         );
-        return data;
-      })
-      .then((data) => initialize(data));
-  });
+        initializeChart(
+            document.getElementById("chart-test262-parser-tests"),
+            charts["test262-parser-tests"]
+        );
+        initializeChart(
+            document.getElementById("chart-test262-performance-tests"),
+            charts["test262-performance-tests"],
+            "Time",
+            "Duration"
+        );
+        initializeChart(
+            document.getElementById("chart-test262-bytecode-performance-tests"),
+            charts["test262-bytecode-performance-tests"],
+            "Time",
+            "Duration"
+        );
+        const last = data.slice(-1)[0];
+        initializeSummary(
+            document.getElementById("summary-test262"),
+            last.run_timestamp,
+            last.versions.serenity,
+            last.tests.test262.duration,
+            last.tests.test262.results
+        );
+        initializeSummary(
+            document.getElementById("summary-test262-bytecode"),
+            last.run_timestamp,
+            last.versions.serenity,
+            last.tests["test262-bytecode"].duration,
+            last.tests["test262-bytecode"].results
+        );
+        initializeSummary(
+            document.getElementById("summary-test262-parser-tests"),
+            last.run_timestamp,
+            last.versions.serenity,
+            last.tests["test262-parser-tests"].duration,
+            last.tests["test262-parser-tests"].results
+        );
+    }
+
+    document.addEventListener("DOMContentLoaded", () => {
+        const headers = new Headers();
+        headers.append("pragma", "no-cache");
+        headers.append("cache-control", "no-cache");
+        fetch(new Request("data/results.json"), {
+                method: "GET",
+                headers
+            })
+            .then((response) => response.json())
+            .then((data) => {
+                data.sort((a, b) =>
+                    a.commit_timestamp === b.commit_timestamp ?
+                    0 :
+                    a.commit_timestamp < b.commit_timestamp ?
+                    -1 :
+                    1
+                );
+                return data;
+            })
+            .then((data) => initialize(data));
+    });
 })();

--- a/test262/main.js
+++ b/test262/main.js
@@ -202,7 +202,8 @@
 
   function initializeChart(
     element,
-    { datasets, metadata, xAxisTitle = "Time", yAxisTitle = "Number of tests" }
+    { datasets, metadata },
+    { xAxisTitle = "Time", yAxisTitle = "Number of tests" } = {}
   ) {
     const ctx = element.getContext("2d");
 
@@ -370,12 +371,12 @@ test262@${test262Version}, test262-parser-tests@${test262ParserTestsVersion}`;
     initializeChart(
       document.getElementById("chart-test262-performance"),
       charts["test262-performance"],
-      { xAxisTitle: "Time", yAxisTitle: TestResultLabels[TestResult.DURATION] }
+      { yAxisTitle: TestResultLabels[TestResult.DURATION] }
     );
     initializeChart(
       document.getElementById("chart-test262-bytecode-performance"),
       charts["test262-bytecode-performance"],
-      { xAxisTitle: "Time", yAxisTitle: TestResultLabels[TestResult.DURATION] }
+      { yAxisTitle: TestResultLabels[TestResult.DURATION] }
     );
     const last = data.slice(-1)[0];
     initializeSummary(

--- a/test262/main.js
+++ b/test262/main.js
@@ -63,7 +63,7 @@
     [TestResult.PROCESS_ERROR]: "Crashed",
     [TestResult.RUNNER_EXCEPTION]: "Unhandled runner exception",
     [TestResult.EXECUTION_TIME]: "Execution time",
-    [TestResult.DURATION]: "Duration",
+    [TestResult.DURATION]: "Duration (seconds)",
   };
 
   function prepareDataForCharts(data) {
@@ -386,13 +386,13 @@ test262@${test262Version}, test262-parser-tests@${test262ParserTestsVersion}`;
       document.getElementById("chart-test262-performance-tests"),
       charts["test262-performance-tests"],
       "Time",
-      "Duration"
+      TestResultLabels[TestResult.DURATION]
     );
     initializeChart(
       document.getElementById("chart-test262-bytecode-performance-tests"),
       charts["test262-bytecode-performance-tests"],
       "Time",
-      "Duration"
+      TestResultLabels[TestResult.DURATION]
     );
     const last = data.slice(-1)[0];
     initializeSummary(

--- a/test262/main.js
+++ b/test262/main.js
@@ -140,42 +140,44 @@
       }
 
       const dt = DateTime.fromSeconds(entry.commit_timestamp);
-      if (dt > PERFORMANCE_CHART_START_DATE_TIME) {
-        // chart-test262-performance
-        const performanceTests = entry.tests["test262"];
-        const performanceChart = charts["test262-performance"];
-        const performanceResults = performanceTests?.results;
-        if (performanceResults) {
-          performanceChart.metadata.push({
-            commitTimestamp: entry.commit_timestamp,
-            runTimestamp: entry.run_timestamp,
-            duration: performanceTests.duration,
-            versions: entry.versions,
-            total: performanceResults.total,
-          });
-          performanceChart.data["duration"].push({
-            x: entry.commit_timestamp * 1000,
-            y: performanceTests.duration,
-          });
-        }
+      if (dt < PERFORMANCE_CHART_START_DATE_TIME) {
+        continue;
+      }
 
-        // chart-test262-bytecode-performance
-        const byteCodePerformanceTests = entry.tests["test262-bytecode"];
-        const byteCodePerformanceChart = charts["test262-bytecode-performance"];
-        const byteCodePerformanceResults = byteCodePerformanceTests?.results;
-        if (byteCodePerformanceResults) {
-          byteCodePerformanceChart.metadata.push({
-            commitTimestamp: entry.commit_timestamp,
-            runTimestamp: entry.run_timestamp,
-            duration: byteCodePerformanceTests.duration,
-            versions: entry.versions,
-            total: byteCodePerformanceResults.total,
-          });
-          byteCodePerformanceChart.data["duration"].push({
-            x: entry.commit_timestamp * 1000,
-            y: byteCodePerformanceTests.duration,
-          });
-        }
+      // chart-test262-performance
+      const performanceTests = entry.tests["test262"];
+      const performanceChart = charts["test262-performance"];
+      const performanceResults = performanceTests?.results;
+      if (performanceResults) {
+        performanceChart.metadata.push({
+          commitTimestamp: entry.commit_timestamp,
+          runTimestamp: entry.run_timestamp,
+          duration: performanceTests.duration,
+          versions: entry.versions,
+          total: performanceResults.total,
+        });
+        performanceChart.data["duration"].push({
+          x: entry.commit_timestamp * 1000,
+          y: performanceTests.duration,
+        });
+      }
+
+      // chart-test262-bytecode-performance
+      const byteCodePerformanceTests = entry.tests["test262-bytecode"];
+      const byteCodePerformanceChart = charts["test262-bytecode-performance"];
+      const byteCodePerformanceResults = byteCodePerformanceTests?.results;
+      if (byteCodePerformanceResults) {
+        byteCodePerformanceChart.metadata.push({
+          commitTimestamp: entry.commit_timestamp,
+          runTimestamp: entry.run_timestamp,
+          duration: byteCodePerformanceTests.duration,
+          versions: entry.versions,
+          total: byteCodePerformanceResults.total,
+        });
+        byteCodePerformanceChart.data["duration"].push({
+          x: entry.commit_timestamp * 1000,
+          y: byteCodePerformanceTests.duration,
+        });
       }
     }
 

--- a/test262/main.js
+++ b/test262/main.js
@@ -61,6 +61,7 @@
     [TestResult.TIMEOUT_ERROR]: "Timed out",
     [TestResult.PROCESS_ERROR]: "Crashed",
     [TestResult.RUNNER_EXCEPTION]: "Unhandled runner exception",
+    [TestResult.EXECUTION_TIME]: "Execution time",
   };
 
   function prepareDataForCharts(data) {
@@ -88,6 +89,13 @@
         data: {
           [TestResult.PASSED]: [],
           [TestResult.FAILED]: [],
+        },
+        datasets: [],
+        metadata: [],
+      },
+      ["test262-performance-tests"]: {
+        data: {
+          [TestResult.EXECUTION_TIME]: [],
         },
         datasets: [],
         metadata: [],
@@ -140,7 +148,7 @@
     return { charts };
   }
 
-  function initializeChart(element, { datasets, metadata }) {
+  function initializeChart(element, { datasets, metadata }, xAxisTitle = "Time", yAxisTitle = "Number of tests") {
     const ctx = element.getContext("2d");
 
     new Chart(ctx, {
@@ -237,7 +245,7 @@ test262@${test262Version}, test262-parser-tests@${test262ParserTestsVersion}`;
             type: "time",
             title: {
               display: true,
-              text: "Time",
+              text: xAxisTitle,
             },
             grid: {
               borderColor: textColor,
@@ -249,7 +257,7 @@ test262@${test262Version}, test262-parser-tests@${test262ParserTestsVersion}`;
             stacked: true,
             title: {
               display: true,
-              text: "Number of tests",
+              text: yAxisTitle,
             },
             grid: {
               borderColor: textColor,
@@ -304,6 +312,12 @@ test262@${test262Version}, test262-parser-tests@${test262ParserTestsVersion}`;
       document.getElementById("chart-test262-parser-tests"),
       charts["test262-parser-tests"]
     );
+    initializeChart(
+      document.getElementById("chart-test262-performance-tests"),
+      charts["test262-performance-tests"],
+      "Date/time",
+      "Execution time"
+    );
     const last = data.slice(-1)[0];
     initializeSummary(
       document.getElementById("summary-test262"),
@@ -326,6 +340,7 @@ test262@${test262Version}, test262-parser-tests@${test262ParserTestsVersion}`;
       last.tests["test262-parser-tests"].duration,
       last.tests["test262-parser-tests"].results
     );
+    // TODO: Init summary for performance
   }
 
   document.addEventListener("DOMContentLoaded", () => {

--- a/test262/main.js
+++ b/test262/main.js
@@ -140,9 +140,8 @@
 
     // chart-test262-performance-tests
     for (const entry of data) {
-      const dateTimeo = DateTime.fromSeconds(entry.commit_timestamp);
-
-      if (dateTimeo > performanceChartStartDateTime) {
+      const dt = DateTime.fromSeconds(entry.commit_timestamp);
+      if (dt > performanceChartStartDateTime) {
         const referenceChart = entry.tests["test262"];
         const chart = charts["test262-performance-tests"];
         const results = referenceChart?.results;
@@ -165,8 +164,8 @@
 
     // chart-test262-bytecode-performance-tests
     for (const entry of data) {
-      const dateTimeo = DateTime.fromSeconds(entry.commit_timestamp);
-      if (dateTimeo > performanceChartStartDateTime) {
+      const dt = DateTime.fromSeconds(entry.commit_timestamp);
+      if (dt > performanceChartStartDateTime) {
         const referenceChart = entry.tests["test262-bytecode"];
         const chart = charts["test262-bytecode-performance-tests"];
         const results = referenceChart?.results;


### PR DESCRIPTION
I would really like to add two graphs showing the performance of the AST and Bytecode interpreter over time, specifically from yesterday when the test started to run on a single machine. It would be good to see performance regressions like Mozilla do in arewefastyet.com.