### PR TITLE
Test262: Add per test performance charts

### DIFF
--- a/test262/index.html
+++ b/test262/index.html
@@ -116,9 +116,21 @@
         </div>
       </section>
       <section>
+        <h2>test262 performance per test</h2>
+        <div class="chart-wrapper">
+          <canvas id="chart-test262-performance-per-test"></canvas>
+        </div>
+      </section>
+      <section>
         <h2>test262 performance in bytecode interpreter</h2>
         <div class="chart-wrapper">
           <canvas id="chart-test262-bytecode-performance"></canvas>
+        </div>
+      </section>
+      <section>
+        <h2>test262 performance in bytecode interpreter per test</h2>
+        <div class="chart-wrapper">
+          <canvas id="chart-test262-bytecode-performance-per-test"></canvas>
         </div>
       </section>
     </main>

--- a/test262/main.js
+++ b/test262/main.js
@@ -106,7 +106,21 @@
         datasets: [],
         metadata: [],
       },
+      ["test262-performance-per-test"]: {
+        data: {
+          [TestResult.DURATION]: [],
+        },
+        datasets: [],
+        metadata: [],
+      },
       ["test262-bytecode-performance"]: {
+        data: {
+          [TestResult.DURATION]: [],
+        },
+        datasets: [],
+        metadata: [],
+      },
+      ["test262-bytecode-performance-per-test"]: {
         data: {
           [TestResult.DURATION]: [],
         },
@@ -162,6 +176,25 @@
         });
       }
 
+      // chart-test262-performance-per-test
+      const performancePerTestTests = entry.tests["test262"];
+      const performancePerTestChart = charts["test262-performance-per-test"];
+      const performancePerTestResults = performancePerTestTests?.results;
+      if (performancePerTestResults) {
+        performancePerTestChart.metadata.push({
+          commitTimestamp: entry.commit_timestamp,
+          runTimestamp: entry.run_timestamp,
+          duration:
+            performancePerTestTests.duration / performancePerTestResults.total,
+          versions: entry.versions,
+          total: performancePerTestResults.total,
+        });
+        performancePerTestChart.data["duration"].push({
+          x: entry.commit_timestamp * 1000,
+          y: performancePerTestTests.duration / performancePerTestResults.total,
+        });
+      }
+
       // chart-test262-bytecode-performance
       const byteCodePerformanceTests = entry.tests["test262-bytecode"];
       const byteCodePerformanceChart = charts["test262-bytecode-performance"];
@@ -177,6 +210,30 @@
         byteCodePerformanceChart.data["duration"].push({
           x: entry.commit_timestamp * 1000,
           y: byteCodePerformanceTests.duration,
+        });
+      }
+
+      // chart-test262-bytecode-performance-per-test
+      const byteCodePerformancePerTestTests = entry.tests["test262-bytecode"];
+      const byteCodePerformancePerTestChart =
+        charts["test262-bytecode-performance-per-test"];
+      const byteCodePerformancePerTestResults =
+        byteCodePerformancePerTestTests?.results;
+      if (byteCodePerformancePerTestResults) {
+        byteCodePerformancePerTestChart.metadata.push({
+          commitTimestamp: entry.commit_timestamp,
+          runTimestamp: entry.run_timestamp,
+          duration:
+            byteCodePerformancePerTestTests.duration /
+            byteCodePerformancePerTestResults.total,
+          versions: entry.versions,
+          total: byteCodePerformancePerTestResults.total,
+        });
+        byteCodePerformancePerTestChart.data["duration"].push({
+          x: entry.commit_timestamp * 1000,
+          y:
+            byteCodePerformancePerTestTests.duration /
+            byteCodePerformancePerTestResults.total,
         });
       }
     }
@@ -377,8 +434,18 @@ test262@${test262Version}, test262-parser-tests@${test262ParserTestsVersion}`;
       { yAxisTitle: TestResultLabels[TestResult.DURATION] }
     );
     initializeChart(
+      document.getElementById("chart-test262-performance-per-test"),
+      charts["test262-performance-per-test"],
+      { yAxisTitle: TestResultLabels[TestResult.DURATION] }
+    );
+    initializeChart(
       document.getElementById("chart-test262-bytecode-performance"),
       charts["test262-bytecode-performance"],
+      { yAxisTitle: TestResultLabels[TestResult.DURATION] }
+    );
+    initializeChart(
+      document.getElementById("chart-test262-bytecode-performance-per-test"),
+      charts["test262-bytecode-performance-per-test"],
       { yAxisTitle: TestResultLabels[TestResult.DURATION] }
     );
     const last = data.slice(-1)[0];


### PR DESCRIPTION
This patch adds a performance chart for test262 and test262-bytecode
that devides the total duration of a test run by the number of tests,
as such resulting in an average runtime per test.