### PR TITLE
Test262: Show percent of tests of TestResult type from the total in tooltips

### DIFF
--- a/test262/main.js
+++ b/test262/main.js
@@ -316,7 +316,18 @@
               label: (context) => {
                 // Space as padding between color circle and label
                 const formattedValue = context.parsed.y.toLocaleString("en-US");
-                return ` ${context.dataset.label}: ${formattedValue}`;
+                if (
+                  context.dataset.label !==
+                  TestResultLabels[TestResult.DURATION]
+                ) {
+                  const { total } = metadata[context.dataIndex];
+                  const percentOfTotal = Math.floor(
+                    (context.parsed.y / total) * 100
+                  );
+                  return ` ${context.dataset.label}: ${formattedValue} (${percentOfTotal}%)`;
+                } else {
+                  return ` ${context.dataset.label}: ${formattedValue}`;
+                }
               },
 
               footer: (context) => {


### PR DESCRIPTION
This patch adds displaying of percent of tests with TestResult type from the total test count in tooltips. I think it's convenient to see for example a fraction of passed tests at some date.