### PR TITLE
repl: Add a little progress bar and a commit indicator

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,6 +37,8 @@
 //
 // Continuously updated test262 results are available at <a href="/test262">/test262</a>.
 //
+// If you wish to play with LibJS in your browser, head over to <a href="/repl">/repl</a>.
+//
 // If you're a SerenityOS contributor and want to do something
 // with this, speak to <a href="https://linus.dev" target="_blank" rel="noopener noreferrer">linusg</a>.</span></code></pre>
     <noscript

--- a/repl/index.html
+++ b/repl/index.html
@@ -16,25 +16,31 @@
 
   <body>
     <main>
-      <h1>LibJS REPL</h1>
-      <small id="input-editor-tip">press 'ctrl+enter' to run</small>
-      <small id="input-tip" style="display: none">press 'enter' to run</small>
-      <div id="repl">
-        <div id="input">
-          <div id="input-textarea">
-            <textarea large id="input-textarea-editor"></textarea>
+      <h1>LibJS REPL<span id="header-description"></span></h1>
+      <div id="main-content" style="display: none">
+        <small id="input-editor-tip">press 'ctrl+enter' to run</small>
+        <small id="input-tip" style="display: none">press 'enter' to run</small>
+        <div id="repl">
+          <div id="input">
+            <div id="input-textarea">
+              <textarea large id="input-textarea-editor"></textarea>
+            </div>
+          </div>
+          <button
+            id="input-toggle"
+            class="input-shown"
+            title="Toggle input editor"
+          >
+            &lt;
+          </button>
+          <div id="repl-window">
+            <div id="repl-contents"></div>
           </div>
         </div>
-        <button
-          id="input-toggle"
-          class="input-shown"
-          title="Toggle input editor"
-        >
-          &lt;
-        </button>
-        <div id="repl-window">
-          <div id="repl-contents"></div>
-        </div>
+      </div>
+      <div id="loading-content">
+        <span id="loading-text">Loading...</span>
+        <progress id="loading-progress"></progress>
       </div>
     </main>
     <footer>

--- a/repl/libjs.js
+++ b/repl/libjs.js
@@ -4877,3 +4877,5 @@ if (typeof window == "object" && (typeof ENVIRONMENT_IS_PTHREAD == 'undefined' |
     emrun_register_handlers();
   }
 }
+
+Module.SERENITYOS_COMMIT = 'dac1685e5c3517fcd0c9924b97026db6c6f1789e';

--- a/repl/main.css
+++ b/repl/main.css
@@ -87,3 +87,7 @@ main {
 .hovered-related {
   background-color: var(--color-hover-highlight);
 }
+
+#loading-content {
+  display: grid;
+}

--- a/repl/main.js
+++ b/repl/main.js
@@ -6,8 +6,24 @@ const outputTemplate = document.getElementById("repl-output-template");
 const inputElement = document.getElementById("input");
 const inputTextArea = inputElement.querySelector("textarea");
 const outputElement = document.getElementById("repl-contents");
+const loadingContainer = document.getElementById("loading-content");
+const mainContainer = document.getElementById("main-content");
+const loadingText = document.getElementById("loading-text");
+const loadingProgress = document.getElementById("loading-progress");
+const headerDescriptionSpan = document.getElementById("header-description");
 
 (async function () {
+  function updateLoading(name, { loaded, total, known }) {
+    loadingText.innerText = `Loading ${name}...`;
+    if (known) {
+      loadingProgress.max = total;
+      loadingProgress.value = loaded;
+    } else {
+      delete loadingProgress.max;
+      delete loadingProgress.value;
+    }
+  }
+
   const repl = await createREPL({
     inputTemplate,
     staticInputTemplate,
@@ -15,7 +31,15 @@ const outputElement = document.getElementById("repl-contents");
     inputElement,
     inputTextArea,
     outputElement,
+    updateLoading,
   });
+
+  const buildHash = Module.SERENITYOS_COMMIT;
+  const shortenedBuildHash = buildHash.substring(0, 7);
+  headerDescriptionSpan.innerHTML = ` (built from <a href="https://github.com/serenityos/serenity/commit/${buildHash}">${shortenedBuildHash}</a>)`;
+
+  loadingContainer.style.display = "none";
+  mainContainer.style.display = "";
 
   repl.display("Ready!");
   inputTextArea.focus();

--- a/repl/repl.js
+++ b/repl/repl.js
@@ -7,9 +7,15 @@ function globalDisplayToUser(text) {
 
 async function createREPL(elements) {
   const repl = Object.create(null);
+  elements.updateLoading("LibJS Runtime", { known: false });
+
   await new Promise((resolve) => addOnPostRun(resolve));
 
-  if (!runtimeInitialized) initRuntime();
+  elements.updateLoading("LibJS WebAssembly Module", { known: false });
+  if (!runtimeInitialized) {
+    initRuntime();
+  }
+
   if (Module._initialize_repl() !== 0)
     throw new Error("Failed to initialize REPL");
 


### PR DESCRIPTION
Just adds a little commit hash and a basic loading progress bar so I don't have to stare at the void while the wasm file is downloaded.
I _could_ provide a download progress, but that's a pain, so...

(Will have to merge before https://github.com/SerenityOS/serenity/pull/16133)

Here's a [preview](https://remote.cxbyte.me/libjs-repl/repl/).