### PR TITLE
Do not pass the UTF-16 length of the string to parse to the REPL

### DIFF
--- a/repl/repl.js
+++ b/repl/repl.js
@@ -98,7 +98,7 @@ async function createREPL(elements) {
       let oldRepl = globalDisplayToUser.repl;
       try {
         globalDisplayToUser.repl = repl.private.outputs;
-        Module._execute(encodedText, text.length);
+        Module._execute(encodedText);
         return repl.private.outputs;
       } finally {
         globalDisplayToUser.repl = oldRepl;


### PR DESCRIPTION
We are currently passing a UTF-8 string with its UTF-16 length, which breaks for basically anything non-ASCII. Emscripten does not provide a method analogous to strlen() to get the length of the string returned by Module.allocateUTF8(), so let the REPL invoke strlen() itself.

Serenity PR: https://github.com/SerenityOS/serenity/pull/16332