### PR TITLE
Pin prettier version in CI linter

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,4 +9,4 @@ jobs:
       - uses: actions/checkout@v2
       - name: Run prettier
         run: |
-          npx prettier --check .
+          npx prettier@2.8.8 --check .


### PR DESCRIPTION
Prettier 3.0.0 was recently released, and our existing style does not match it.